### PR TITLE
macOS deploy: Remove background command note

### DIFF
--- a/guides/Getting_Started/Deployment/macos/index.md
+++ b/guides/Getting_Started/Deployment/macos/index.md
@@ -26,7 +26,7 @@ We've provided sample binaries for you to deploy:
 * Insert your ST-Link V2 into a free USB port on your host PC.
 * Open the terminal.
 * Navigate to the folder where your [downloaded the st-link](https://www.wildernesslabs.co/downloads?f=/Meadow_Beta/STLink.zip).
-* Start st-util using the following command - you should see **Listening at \*:4242...** (the **&** is used to run the script in the background):
+* Start st-util using the following command - you should see **Listening at \*:4242...**:
 
 ```bash
 ./st-util --semihosting -v -m


### PR DESCRIPTION
The note didn't seem relevant, since the following command didn't contain an ampersand. The instructions have us use one terminal for `st-util` and then another for `arm-none-eabi-gdb`, so this note about backgrounding the st-util command might have just been outdated.