### PR TITLE
Clarify deployment wait expectations.

### DIFF
--- a/guides/Getting_Started/Deployment/macos/index.md
+++ b/guides/Getting_Started/Deployment/macos/index.md
@@ -13,8 +13,8 @@ To deploy an app to Meadow you'll need several things:
 1. Follow the steps in the [Setup](/guides/Getting_Started/Setup/index.html). 
 1. Open the terminal.
 
-
 ## Prepare your app for deployment
+
 1. Compile your .NET 4.7.2 console app in Visual Studio for Mac
 1. Copy the **app files** into the **/tmp** root folder on your mac (hint - use *Finder -> Go -> Go to Folder...*).
 We've provided sample binaries for you to deploy:
@@ -22,6 +22,7 @@ We've provided sample binaries for you to deploy:
 3. Copy the provided **[mscorlib.dll](https://www.wildernesslabs.co/downloads?f=/Meadow_Beta/binaries/mscorlib.dll)** and **[System.Core.dll](https://www.wildernesslabs.co/downloads?f=/Meadow_Beta/binaries/System.Core.dll)** into the **/tmp** folder.
 
 ## Connect Meadow to your mac
+
 1. Follow this instructions to [connect your ST-Link V2 to Meadow](/guides/Getting_Started/Setup/stlink/index.html).
 * Insert your ST-Link V2 into a free USB port on your host PC.
 * Open the terminal.
@@ -33,18 +34,20 @@ We've provided sample binaries for you to deploy:
 ```
 
 ## Start the application
+
 1. Open a second terminal.
 1. Enter `arm-none-eabi-gdb` to start a gdb debug session (no debug symbols are currently available).
 1. From the gdb prompt, enter `target remote :4242`.
 1. Enter `c` to start the application.
 
-The application may take several minutes to deploy. You'll see periods appear in the terminal indicating progress. Once the app is fully deployed, it will start running on Meadow. Any `Console.WriteLine` commands will appear in the terminal.
+The application may take several minutes to deploy. You'll see periods appear in the initial `st-util` terminal indicating progress. Once the app is fully deployed, it will start running on Meadow. Any `Console.WriteLine` commands will appear in the terminal.
 
 If you ran the provided sample app, you should see the RGB led changing color!
 
 ![Meadow app deploying](./app_deploy.png)
 
 ## Stop the application
+
 1. Press control-C to stop debugging.
 1. Enter `quit` to close gdb.
 1. st-util will continue listening on port 4242; you can now update the application in the tmp folder and restart GDB to deploy your updated app.


### PR DESCRIPTION
Since the background system was no longer used in the instructions (note removed in #3), the screenshot made it seem like the loading periods (`....`) were going to appear in the second, `arm-none-eabi-gdb` terminal. With two terminals, this clarifies that the user should see those loading indicators in their first, `st-link` terminal.

Additionally, the image reflects the prior backgrounding system. If you want a new screenshot to update that, I've attached one but not put it in place for this PR that you are welcome to use.

<img width="682" alt="Screen Shot 2019-04-09 at 9 33 05 PM" src="https://user-images.githubusercontent.com/713665/55849932-a6a55180-5b0f-11e9-972e-e1163cb1b083.png">
