### PR TITLE
Hello world code typo fixes

### DIFF
--- a/guides/Getting_Started/Hello_World/index.md
+++ b/guides/Getting_Started/Hello_World/index.md
@@ -65,7 +65,7 @@ Install the latest version of Visual Studio for Mac.
 
 ## Set the App assembly name
 
-Currently, Meadow is configured to run a .NET console app named **app.exe**. You can either manually rename your application after its compiled or change the assembly name in Visual Studio.
+Currently, Meadow is configured to run a .NET console app named **App.exe**. You can either manually rename your application after its compiled or change the assembly name in Visual Studio.
 
 ### Windows
 
@@ -210,7 +210,7 @@ You're now ready to build and deploy your Meadow app.
 
  1. Build the application.
  * Using Finder or the File Explorer, navigate to the folder that contains your application.
- * Open the **bin->Debug** folder, you should see **app.exe** and some **\*.dll** files; you'll need both to deploy your app to Meadow.
+ * Open the **bin->Debug** folder, you should see **App.exe** and some **\*.dll** files; you'll need both to deploy your app to Meadow.
  * Follow the [Deployment instructions here](../Deployment/index.html) to deploy your app.
 
 

--- a/guides/Getting_Started/Hello_World/index.md
+++ b/guides/Getting_Started/Hello_World/index.md
@@ -131,9 +131,9 @@ Now we'll add fields to control the onboard LED and toggle its red, green, and b
 
   void InitializeHardware()
   {
-      redLED = Device.CreateDigitalOutputPort(Device.Pins.OnboardLEDRed);
-      blueLED = Device.CreateDigitalOutputPort(Device.Pins.OnboardLEDBlue);
-      greenLED = Device.CreateDigitalOutputPort(Device.Pins.OnboardLEDGreen);
+      redLed = Device.CreateDigitalOutputPort(Device.Pins.OnboardLEDRed);
+      blueLed = Device.CreateDigitalOutputPort(Device.Pins.OnboardLEDBlue);
+      greenLed = Device.CreateDigitalOutputPort(Device.Pins.OnboardLEDGreen);
   }
   ```
 


### PR DESCRIPTION
Had a mismatch in casing on the `redLed` variables (and friends) that I noticed when copy-pasting to my first app.

Wasn't 100% sure on case-sensitivity with "app.exe" vs. "App.exe", but going uppercase matched what is in the pre-built sample app.